### PR TITLE
Fixed tests involving gettext

### DIFF
--- a/roles/djangodata/tasks/main.yml
+++ b/roles/djangodata/tasks/main.yml
@@ -55,3 +55,7 @@
     - npm
     - nodejs-legacy
     - phantomjs
+
+- name: install gettext
+  become: yes
+  apt: pkg=gettext


### PR DESCRIPTION
Tests which require gettext throw errors:

```
======================================================================
FAIL: test_makemessages_no_settings (i18n.test_extraction.NoSettingsExtractionTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/unittest/case.py", line 329, in run
    testMethod()
  File "/django/tests/i18n/test_extraction.py", line 723, in test_makemessages_no_settings
    self.assertNoOutput(err)
  File "/django/tests/admin_scripts/tests.py", line 203, in assertNoOutput
    self.assertEqual(len(stream), 0, "Stream should be empty: actually contains '%s'" % stream)
  File "/usr/lib/python2.7/unittest/case.py", line 513, in assertEqual
    assertion_func(first, second, msg=msg)
  File "/usr/lib/python2.7/unittest/case.py", line 506, in _baseAssertEqual
    raise self.failureException(msg)
AssertionError: Stream should be empty: actually contains 'CommandError: Can't find msguniq. Make sure you have GNU gettext tools 0.15 or newer installed.
```

This patch makes sure that gettext is included while building the box.