### PR TITLE
Always newest chromedriver

### DIFF
--- a/roles/browsers/tasks/main.yml
+++ b/roles/browsers/tasks/main.yml
@@ -29,9 +29,13 @@
   become: yes
   apt: name=unzip state=present
 
+- name: get chromedriver version
+  uri: url=https://chromedriver.storage.googleapis.com/LATEST_RELEASE return_content=yes
+  register: chromedriver_version_file
+
 - name: download chromedriver
   become: yes
-  unarchive: src=https://chromedriver.storage.googleapis.com/{{ chromedriver_version }}/chromedriver_linux{{ ansible_userspace_bits }}.zip dest=/tmp copy=no
+  unarchive: src=https://chromedriver.storage.googleapis.com/{{ chromedriver_version_file.content|replace('\n','') }}/chromedriver_linux{{ ansible_userspace_bits }}.zip dest=/tmp copy=no
 
 - name: copy executable file for chromedriver
   become: yes

--- a/roles/browsers/vars/main.yml
+++ b/roles/browsers/vars/main.yml
@@ -1,1 +1,0 @@
-chromedriver_version: '2.22'


### PR DESCRIPTION
Selenium tests fail on the current django box because during box creation the newest version of chrome is installed, but the version of chromedriver is based on a variable.

This change will make sure that the newest version of chromedriver is always installed.

This should fix #21 